### PR TITLE
Mark as empty

### DIFF
--- a/src/lib/server/logic/_ingredient-stock.ts
+++ b/src/lib/server/logic/_ingredient-stock.ts
@@ -12,7 +12,7 @@ import { getFirstIfPosible } from '$lib/utils';
 const batches_in_production = alias(t_ingredient_batch, 'batches_in_production');
 
 /*
- * This show the availale amount of a batch sonidering that the amouns that are alredy
+ * This show the availale amount of a batch considering that the amounts that are already
  * assigned to a production are not available, even if the production is not finished
  * */
 export const sq_stock = db.$with('stock').as(

--- a/src/lib/server/logic/_ingredient-stock.ts
+++ b/src/lib/server/logic/_ingredient-stock.ts
@@ -1,14 +1,20 @@
 import {
 	t_ingredient_batch,
+	t_product_batch,
 	tr_ingredient_batch_ingredient_batch,
 	tr_product_batch_ingredient_batch
 } from '../db/schema';
 import { db, type Tx } from '../db';
-import { eq, sql, sum } from 'drizzle-orm';
+import { and, eq, sql, sum } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import { getFirstIfPosible } from '$lib/utils';
 
 const batches_in_production = alias(t_ingredient_batch, 'batches_in_production');
+
+/*
+ * This show the availale amount of a batch sonidering that the amouns that are alredy
+ * assigned to a production are not available, even if the production is not finished
+ * */
 export const sq_stock = db.$with('stock').as(
 	db
 		.select({
@@ -22,7 +28,6 @@ export const sq_stock = db.$with('stock').as(
 				.as('currently_available')
 		})
 		.from(t_ingredient_batch)
-		.where(eq(t_ingredient_batch.state, 'AVAILABLE'))
 		.leftJoin(
 			tr_ingredient_batch_ingredient_batch,
 			eq(tr_ingredient_batch_ingredient_batch.used_batch_id, t_ingredient_batch.id)
@@ -35,15 +40,76 @@ export const sq_stock = db.$with('stock').as(
 			tr_product_batch_ingredient_batch,
 			eq(tr_product_batch_ingredient_batch.ingredient_batch_id, t_ingredient_batch.id)
 		)
+		.where(and(eq(t_ingredient_batch.state, 'AVAILABLE')))
+		.groupBy(t_ingredient_batch.id)
+);
+
+/* Auxilar table for sq_material_stock*/
+const sq_produced_batch_ingredients = db.$with('sq_produced_batch_ingredients').as(
+	db
+		.select({
+			used_batch_id: tr_ingredient_batch_ingredient_batch.used_batch_id,
+			amount_used: tr_ingredient_batch_ingredient_batch.amount_used_to_produce_batch
+		})
+		.from(tr_ingredient_batch_ingredient_batch)
+		.innerJoin(
+			t_ingredient_batch,
+			eq(tr_ingredient_batch_ingredient_batch.produced_batch_id, t_ingredient_batch.id)
+		)
+		.where(eq(t_ingredient_batch.state, 'AVAILABLE'))
+);
+
+/* Auxilar table for sq_material_stock*/
+const sq_produced_batch_products = db.$with('sq_produced_batch_products').as(
+	db
+		.select({
+			used_batch_id: tr_product_batch_ingredient_batch.ingredient_batch_id,
+			amount_used: tr_product_batch_ingredient_batch.amount_used_to_produce_batch
+		})
+		.from(tr_product_batch_ingredient_batch)
+		.innerJoin(
+			t_product_batch,
+			eq(tr_product_batch_ingredient_batch.produced_batch_id, t_product_batch.id)
+		)
+		.where(eq(t_product_batch.state, 'AVAILABLE'))
+);
+
+/*
+ * This show the availale amount of a batch considering that the stock is gone
+ * once the produciton (of ingredient or product) are finished
+ * */
+export const sq_material_stock = db.$with('stock').as(
+	db
+		.with(sq_produced_batch_ingredients, sq_produced_batch_products)
+		.select({
+			batch_id: t_ingredient_batch.id,
+			currently_available: sql<number>`
+          + ${t_ingredient_batch.initial_amount}
+          - COALESCE(${sum(sq_produced_batch_ingredients.amount_used)} ,0) 
+          - COALESCE(${sum(sq_produced_batch_products.amount_used)} ,0) 
+          + COALESCE(${t_ingredient_batch.adjustment}, 0)`
+				.mapWith(Number)
+				.as('currently_available')
+		})
+		.from(t_ingredient_batch)
+		.leftJoin(
+			sq_produced_batch_ingredients,
+			eq(sq_produced_batch_ingredients.used_batch_id, t_ingredient_batch.id)
+		)
+		.leftJoin(
+			sq_produced_batch_products,
+			eq(sq_produced_batch_products.used_batch_id, t_ingredient_batch.id)
+		)
+		.where(eq(t_ingredient_batch.state, 'AVAILABLE'))
 		.groupBy(t_ingredient_batch.id)
 );
 
 export async function check_if_empry_and_mark(batch_id: number, tx?: Tx) {
 	const batch = await (tx ?? db)
-		.with(sq_stock)
+		.with(sq_material_stock)
 		.select()
-		.from(sq_stock)
-		.where(eq(sq_stock.batch_id, batch_id))
+		.from(sq_material_stock)
+		.where(eq(sq_material_stock.batch_id, batch_id))
 		.then(getFirstIfPosible);
 
 	if (!batch) return 'batch not found';

--- a/src/lib/server/logic/_ingredient-stock.ts
+++ b/src/lib/server/logic/_ingredient-stock.ts
@@ -46,8 +46,14 @@ export async function check_if_empry_and_mark(batch_id: number, tx?: Tx) {
 		.where(eq(sq_stock.batch_id, batch_id))
 		.then(getFirstIfPosible);
 
-	if (!batch) return;
-	if (batch.currently_available != 0) return;
+	if (!batch) return 'batch not found';
 
-	await (tx ?? db).update(t_ingredient_batch).set({ state: 'EMPTY' });
+	if (batch.currently_available !== 0) return 'stock is OK';
+
+	await (tx ?? db)
+		.update(t_ingredient_batch)
+		.set({ state: 'EMPTY' })
+		.where(eq(t_ingredient_batch.id, batch_id));
+
+	return 'marked as EMPTY';
 }

--- a/src/lib/server/logic/ingredient-production-service.ts
+++ b/src/lib/server/logic/ingredient-production-service.ts
@@ -417,6 +417,8 @@ class IngredientProductionService {
 				.update(t_ingredient_batch)
 				.set({ adjustment: Number(batch.adjustment) + adjustment })
 				.where(eq(t_ingredient_batch.id, batch_id));
+
+			await check_if_empry_and_mark(batch_id, tx);
 			return is_ok(null);
 		});
 	}

--- a/src/lib/server/logic/ingredient-production-service.ts
+++ b/src/lib/server/logic/ingredient-production-service.ts
@@ -59,7 +59,8 @@ class IngredientProductionService {
 					'id',
 					'batch_code',
 					'expiration_date',
-					'initial_amount'
+					'initial_amount',
+					'state'
 				),
 				ingredient: pick_columns(t_ingredient, 'id', 'name', 'unit'),
 				stock: { current_amount: sq_stock.currently_available }

--- a/src/lib/server/logic/ingredient-production-service.ts
+++ b/src/lib/server/logic/ingredient-production-service.ts
@@ -8,7 +8,7 @@ import {
 } from '../db/schema';
 import { eq, and, asc, desc, ne, count, inArray, sql, ilike } from 'drizzle-orm';
 import { drizzle_map, copy_column, pick_columns } from 'drizzle-tools';
-import { sq_stock } from './_ingredient-stock';
+import { check_if_empry_and_mark, sq_stock } from './_ingredient-stock';
 import { pick_merge } from 'drizzle-tools/src/pick-columns';
 import { alias } from 'drizzle-orm/pg-core';
 import { ingredients_service } from './ingredient-service';
@@ -351,6 +351,16 @@ class IngredientProductionService {
 					adjustment
 				})
 				.where(eq(t_ingredient_batch.id, batch_id));
+
+			const used_batches = await tx
+				.select()
+				.from(tr_ingredient_batch_ingredient_batch)
+				.where(eq(tr_ingredient_batch_ingredient_batch.produced_batch_id, batch_id));
+			const used_batches_id = used_batches.map((x) => x.used_batch_id);
+			for (const id of used_batches_id) {
+				await check_if_empry_and_mark(id, tx);
+			}
+
 			return { type: 'SUCCESS' } as const;
 		});
 	}

--- a/src/lib/server/logic/test/ingredients/ingr-mark-as-emptry.spec.ts
+++ b/src/lib/server/logic/test/ingredients/ingr-mark-as-emptry.spec.ts
@@ -1,0 +1,131 @@
+import { describe, vi, test, expect, beforeEach, beforeAll } from 'vitest';
+import { db } from '$lib/server/db/__mocks__';
+import {
+	t_entry_document,
+	t_ingredient_batch,
+	t_ingridient_entry,
+	t_product_batch,
+	tr_ingredient_batch_ingredient_batch,
+	tr_product_batch_ingredient_batch
+} from '$lib/server/db/schema';
+import { __DELETE_ALL_DATABASE } from '../utils';
+import { getFirst } from '$lib/utils';
+import { ingredient_defaulter_service } from '$logic/defaulters/ingredient-service.default';
+import { suppliers_defaulter_service } from '$logic/defaulters/supplier-service.default';
+import { purchases_defaulter_service } from '$logic/defaulters/purchase-service.default';
+import { product_service } from '$logic/product-service';
+import { product_service_defaulter } from '$logic/defaulters/product-service.default';
+import { ingredient_production_service } from '$logic/ingredient-production-service';
+
+vi.mock('$lib/server/db/index.ts');
+
+let LIVER_ID = -1;
+let SUPPLIER_ID = -1;
+let PRODUCT_ID = -1;
+
+beforeAll(async () => {
+	await __DELETE_ALL_DATABASE();
+	LIVER_ID = await ingredient_defaulter_service.add_simple();
+	SUPPLIER_ID = await suppliers_defaulter_service.add({ ingredientsIds: [LIVER_ID] });
+	PRODUCT_ID = await product_service_defaulter.add([{ ingredient_id: LIVER_ID, amount: 10 }]);
+});
+beforeEach(async () => {
+	await db.delete(tr_product_batch_ingredient_batch);
+	await db.delete(t_product_batch);
+	await db.delete(tr_ingredient_batch_ingredient_batch);
+	await db.delete(t_ingredient_batch);
+	await db.delete(t_entry_document);
+	await db.delete(t_ingridient_entry);
+});
+
+describe.sequential('check if ingredient batch is empty and mark', () => {
+	test('change state to EMPYT when production ends', async () => {
+		const batch_id = await purchases_defaulter_service
+			.buy({
+				supplier_id: SUPPLIER_ID,
+				bought: [{ ingredient_id: LIVER_ID, initial_amount: 100 }]
+			})
+			.then(getFirst);
+
+		const res1 = await product_service.startProduction({
+			product_id: PRODUCT_ID,
+			recipe: [{ ingredient_id: LIVER_ID, amount: 10 }],
+			produced_amount: 10,
+			batches_ids: [[batch_id]]
+		});
+		expect(res1.type).toBe('SUCCESS');
+		if (res1.type != 'SUCCESS') return;
+
+		const still_batch = await ingredient_production_service.getBatchById(batch_id);
+		expect(still_batch?.state).toBe('AVAILABLE');
+
+		const res2 = await product_service.closeProduction({ batch_id: res1.data.id, adjustment: 0 });
+
+		expect(res2.type).toBe('SUCCESS');
+		if (res2.type != 'SUCCESS') return;
+
+		const mod_batch = await ingredient_production_service.getBatchById(batch_id);
+		expect(mod_batch?.state).toBe('EMPTY');
+	});
+
+	test('change state to EMPYT when production ends (2 productions)', async () => {
+		const batch_id = await purchases_defaulter_service
+			.buy({
+				supplier_id: SUPPLIER_ID,
+				bought: [{ ingredient_id: LIVER_ID, initial_amount: 100 }]
+			})
+			.then(getFirst);
+
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		for (const _ of [1, 2]) {
+			const res1 = await product_service.startProduction({
+				product_id: PRODUCT_ID,
+				recipe: [{ ingredient_id: LIVER_ID, amount: 10 }],
+				produced_amount: 5,
+				batches_ids: [[batch_id]]
+			});
+			expect(res1.type).toBe('SUCCESS');
+			if (res1.type != 'SUCCESS') return;
+
+			const still_batch = await ingredient_production_service.getBatchById(batch_id);
+			expect(still_batch?.state).toBe('AVAILABLE');
+
+			const res2 = await product_service.closeProduction({ batch_id: res1.data.id, adjustment: 0 });
+
+			expect(res2.type).toBe('SUCCESS');
+			if (res2.type != 'SUCCESS') return;
+		}
+
+		const mod_batch = await ingredient_production_service.getBatchById(batch_id);
+		expect(mod_batch?.state).toBe('EMPTY');
+	});
+
+	test('dont change state to EMPYT when production ends and stock>0', async () => {
+		const batch_id = await purchases_defaulter_service
+			.buy({
+				supplier_id: SUPPLIER_ID,
+				bought: [{ ingredient_id: LIVER_ID, initial_amount: 100 }]
+			})
+			.then(getFirst);
+
+		const res1 = await product_service.startProduction({
+			product_id: PRODUCT_ID,
+			recipe: [{ ingredient_id: LIVER_ID, amount: 9 }], // << IMPORTANT!
+			produced_amount: 10,
+			batches_ids: [[batch_id]]
+		});
+		expect(res1.type).toBe('SUCCESS');
+		if (res1.type != 'SUCCESS') return;
+
+		const still_batch = await ingredient_production_service.getBatchById(batch_id);
+		expect(still_batch?.state).toBe('AVAILABLE');
+
+		const res2 = await product_service.closeProduction({ batch_id: res1.data.id, adjustment: 0 });
+
+		expect(res2.type).toBe('SUCCESS');
+		if (res2.type != 'SUCCESS') return;
+
+		const mod_batch = await ingredient_production_service.getBatchById(batch_id);
+		expect(mod_batch?.state).toBe('AVAILABLE');
+	});
+});

--- a/src/lib/server/logic/test/ingredients/ingr-mark-as-emptry.spec.ts
+++ b/src/lib/server/logic/test/ingredients/ingr-mark-as-emptry.spec.ts
@@ -439,3 +439,41 @@ describe.sequential('check_if_empry_and_mark: ingreidient production', () => {
 		});
 	});
 });
+
+describe.sequential('check_if_empry_and_mark: adjustment', () => {
+	test('mark as EMPTY when stock adjusted (once)', async () => {
+		const batch_id = await purchases_defaulter_service
+			.buy({
+				supplier_id: SUPPLIER_ID,
+				bought: [{ ingredient_id: LIVER_ID, initial_amount: 10 }]
+			})
+			.then(getFirst);
+
+		await ingredient_production_service.modifyStock({ batch_id, adjustment: -10 });
+
+		await ingredient_production_service.getBatchById(batch_id).then((x) => {
+			expect(x?.state).toBe('EMPTY');
+		});
+	});
+
+	test('mark as EMPTY when stock adjusted (twice)', async () => {
+		const batch_id = await purchases_defaulter_service
+			.buy({
+				supplier_id: SUPPLIER_ID,
+				bought: [{ ingredient_id: LIVER_ID, initial_amount: 10 }]
+			})
+			.then(getFirst);
+
+		await ingredient_production_service.modifyStock({ batch_id, adjustment: -5 });
+
+		await ingredient_production_service.getBatchById(batch_id).then((x) => {
+			expect(x?.state).toBe('AVAILABLE');
+		});
+
+		await ingredient_production_service.modifyStock({ batch_id, adjustment: -5 });
+
+		await ingredient_production_service.getBatchById(batch_id).then((x) => {
+			expect(x?.state).toBe('EMPTY');
+		});
+	});
+});

--- a/src/lib/server/logic/test/ingredients/ingr-mark-as-emptry.spec.ts
+++ b/src/lib/server/logic/test/ingredients/ingr-mark-as-emptry.spec.ts
@@ -70,7 +70,7 @@ describe.sequential('check_if_empry_and_mark: product production', () => {
 		expect(mod_batch?.state).toBe('EMPTY');
 	});
 
-	test('change state to EMPYT when production ends (2 productions)', async () => {
+	test('change state to EMPTY when production ends (2 productions)', async () => {
 		const batch_id = await purchases_defaulter_service
 			.buy({
 				supplier_id: SUPPLIER_ID,
@@ -121,7 +121,7 @@ describe.sequential('check_if_empry_and_mark: product production', () => {
 		});
 	});
 
-	test('dont change state to EMPYT when production ends and stock>0', async () => {
+	test('do not change state to EMPTY when production ends and stock>0', async () => {
 		const batch_id = await purchases_defaulter_service
 			.buy({
 				supplier_id: SUPPLIER_ID,
@@ -150,7 +150,7 @@ describe.sequential('check_if_empry_and_mark: product production', () => {
 		expect(mod_batch?.state).toBe('AVAILABLE');
 	});
 
-	test('production of product, empty the first batch but not the second', async () => {
+	test('production of product, EMPTY the first batch but not the second', async () => {
 		const batch_id_1 = await purchases_defaulter_service
 			.buy({
 				supplier_id: SUPPLIER_ID,
@@ -261,7 +261,7 @@ describe.sequential('check_if_empry_and_mark: ingreidient production', () => {
 		expect(mod_batch?.state).toBe('EMPTY');
 	});
 
-	test('change state to EMPYT when production ends (2 productions)', async () => {
+	test('change state to EMPTY when production ends (2 productions)', async () => {
 		const batch_id = await purchases_defaulter_service
 			.buy({
 				supplier_id: SUPPLIER_ID,
@@ -327,7 +327,7 @@ describe.sequential('check_if_empry_and_mark: ingreidient production', () => {
 		});
 	});
 
-	test('dont change state to EMPTY when production ends and stock>0', async () => {
+	test('do not change state to EMPTY when production ends and stock>0', async () => {
 		const batch_id = await purchases_defaulter_service
 			.buy({
 				supplier_id: SUPPLIER_ID,
@@ -361,7 +361,7 @@ describe.sequential('check_if_empry_and_mark: ingreidient production', () => {
 		}
 	});
 
-	test('mark EMPYT the first batch but not the second', async () => {
+	test('mark EMPTY the first batch but not the second', async () => {
 		const batch_id_1 = await purchases_defaulter_service
 			.buy({
 				supplier_id: SUPPLIER_ID,
@@ -400,7 +400,7 @@ describe.sequential('check_if_empry_and_mark: ingreidient production', () => {
 		});
 	});
 
-	test('mark EMPYT both batches', async () => {
+	test('mark EMPTY both batches', async () => {
 		const batch_id_1 = await purchases_defaulter_service
 			.buy({
 				supplier_id: SUPPLIER_ID,


### PR DESCRIPTION
When a production is closed or a stock is modified, we evaluate if it is empty and make it as "EMPTY" in the state column.
There is not a way in this PR to undo a mark, but we can add it.

The idea of the mark is avoid performance issues in the future, omitting old batches that are empty.

We might discuss if this is needed now or not....